### PR TITLE
add new issue forms and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,52 @@
+name: "Bug Report"
+description: "Report a bug to help us improve."
+title: "[Bug]: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: "## Bug Report"
+  - type: input
+    id: summary
+    attributes:
+      label: "Bug Summary"
+      description: "Provide a short summary of the bug."
+      placeholder: "A brief description of the issue."
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: "Steps to Reproduce"
+      description: "List the steps to reproduce the bug."
+      placeholder: "1. Go to '...'
+2. Click on '...'
+3. See error"
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: "Expected Behavior"
+      description: "Describe what you expected to happen."
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: "Actual Behavior"
+      description: "Describe what actually happened."
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: "Environment"
+      description: "Provide details about your environment (OS, dependencies, etc.)."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: "Proposed Solution"
+      description: "If applicable, describe how you think the issue can be fixed."

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,41 @@
+name: "Feature Request"
+description: "Suggest a new feature or enhancement."
+title: "[Feature]: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: "## Feature Request"
+  - type: input
+    id: summary
+    attributes:
+      label: "Feature Summary"
+      description: "Provide a short summary of the feature request."
+      placeholder: "A brief description of the feature."
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: "Full Description"
+      description: "Provide a detailed explanation of the feature, including goals, benefits, and potential use cases."
+      placeholder: "Describe the feature in detail..."
+  - type: textarea
+    id: related-programs
+    attributes:
+      label: "Related Programs"
+      description: "Does this feature relate to any existing program or module?"
+  - type: textarea
+    id: how-to-review
+    attributes:
+      label: "How to Review"
+      description: "Explain how this feature should be reviewed and tested."
+    validations:
+      required: true
+  - type: textarea
+    id: implementation-approach
+    attributes:
+      label: "Implementation Approach"
+      description: "Detail the approach to implementing this feature."
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+**Descriptions**
+
+This pull request introduces a new feature or enhancement and aligns with existing development practices.
+
+**Tasks**
+- [ ] Implement the feature as described in the related issue.
+- [ ] Ensure all required files are updated.
+- [ ] Validate functionality through testing.
+
+**How to check locally**
+- Clone the repository if not already available:  
+  ```shell
+  git clone https://github.com/hackerbotindustries/hackerbot-firmware-main-controller.git
+  ```
+- Navigate to the project directory:
+  ```shell
+  cd hackerbot-firmware-main-controller
+  ```
+- Switch to this branch:
+  ```shell
+  git fetch
+  git checkout <branch-name>
+  git pull
+  ```
+- Review modified files and ensure expected changes.
+- Execute relevant tests and confirm the feature works as intended.
+- Validate usability and performance of the new feature.
+
+**Reviewer Checklist**
+- [ ] Verify that the issue description is clear and comprehensive.
+- [ ] Check if the bug is reproducible before and resolved after the fix.
+- [ ] Review code changes for correctness and adherence to coding guidelines.
+- [ ] Ensure all related files are correctly updated.
+- [ ] Confirm that all necessary tests have been run and passed.
+- [ ] Validate that no new bugs are introduced by the fix.
+- [ ] Looks good to merge!


### PR DESCRIPTION
This pull request aims to provide clear and smooth templates for users to report bugs and request features, and set up standards in pull requests to ensure the smoothness of reviewing and testing.

**Tasks**
- [x] Implemented issue forms for bug reports and feature requests.
- [x] Implemented pull request template.

**How to check locally**
Go to the following links to preview these files, and make sure it aligns with [software developement guidelines](https://docs.google.com/document/d/1RyrNu6HJcmqxOT8r6_fz_F-q1TMWdkMfF-8DHSGOEjQ/edit?tab=t.0#heading=h.frh963tnn7rw):
- [x] Issue form for bug reports `.github/ISSUE_TEMPLATE/bug_report.yaml`
- [x] Issue form for feature requests `.github/ISSUE_TEMPLATE/feature_request.yaml`
- [x] Pull request template `.github/pull_request_template.md`

**Reviewer Checklist**
- [x] Verify that the files meet Hackerbot's software developement guidelines.
- [x] Verify that there's no typo or messy writing in the files.
- [x] Looks good to merge!